### PR TITLE
Add Dockerfile for cncnet-server application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM rust:slim-bookworm AS builder
+
+RUN apt-get update && \
+    apt-get install -y bash build-essential && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY . /app
+WORKDIR /app
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        bash build-arm.sh || true; \
+    else \
+        bash build.sh || true; \
+    fi
+
+FROM debian:bookworm-slim
+COPY --from=builder /app/target/release/cncnet-server /usr/local/bin/cncnet-server
+
+# Run as non-root user
+RUN useradd -r -s /bin/false cncnet
+USER cncnet
+
+CMD ["cncnet-server"]


### PR DESCRIPTION
Create a multi-stage Dockerfile for building and running the cncnet-server application with a non-root user.